### PR TITLE
fix duplicated route declaration

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -16,15 +16,6 @@ app.use('/order', orderRoutes);
 app.use('/reports', reportsRouter);
 app.use('/employees', employeesRouter);
 
-// Middleware
-app.use(express.json());
-
-// Routes
-const reportsRouter = require('./routes/report.route');
-const employeesRouter = require('./routes/employee.route');
-
-app.use('/reports', reportsRouter);
-app.use('/employees', employeesRouter);
 
 app.get("/", (req, res) => {
   res.json({


### PR DESCRIPTION
This pull request fixed my own mistake 🥺, which includes a modification to the `backend/src/server.js` file by removing duplicated middleware and route declarations.

Changes to route setup:

* Removed duplicated middleware (`express.json()`) and restructured the imports and usage of `reportsRouter` and `employeesRouter` to avoid duplication.