### PR TITLE
feat(docker): add phpMyAdmin service to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,23 @@ services:
     networks:
       - backend-net
 
+  phpmyadmin:
+    image: phpmyadmin:5-apache
+    container_name: database-client
+    networks:
+      - backend-net
+    restart: always
+    ports:
+      - 8080:80
+    env_file:
+      - .env
+    environment:
+      PMA_HOST: ${DB_HOST}
+      PMA_PORT: 3306
+      PMA_USER: ${DB_USER}
+      PMA_PASSWORD: ${DB_PASSWORD}
+      PMA_ARBITRARY: 1
+
 networks:
   app-network:
   backend-net:


### PR DESCRIPTION
This pull request adds a new service configuration for `phpMyAdmin` in the `docker-compose.yml` file. The service is set up to provide a web-based interface for managing the database.

Key change:

* **Added `phpMyAdmin` service**: Introduced a `phpmyadmin` service with the `phpmyadmin:5-apache` image. The service is configured to run on port `8080`, connect to the `backend-net` network, and use environment variables for database connection details. It also includes automatic restart settings.