### PR TITLE
feat: Add express-validator dependency for input validation

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,6 +12,7 @@
         "argon2": "^0.43.0",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
+        "express-validator": "^7.2.1",
         "mariadb": "^3.4.1"
       }
     },
@@ -321,6 +322,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-validator": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
+      "integrity": "sha512-CjNE6aakfpuwGaHQZ3m8ltCG2Qvivd7RHtVMS/6nVxOM7xVGqr4bhflsm4+N5FP5zI7Zxp+Hae+9RE+o8e3ZOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "~13.12.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
@@ -485,6 +499,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -895,6 +915,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
     "argon2": "^0.43.0",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
+    "express-validator": "^7.2.1",
     "mariadb": "^3.4.1"
   }
 }


### PR DESCRIPTION
This pull request adds the `express-validator` library to the project and updates the `package.json` and `package-lock.json` files accordingly. The most important changes include the addition of `express-validator` as a dependency, along with its related sub-dependencies (`lodash` and `validator`).

### Dependency Additions:

* Added `express-validator` version `^7.2.1` to `dependencies` in `backend/package.json` and `backend/package-lock.json`. This library provides middleware for validating and sanitizing user input in Express applications. [[1]](diffhunk://#diff-495707834ca4b862f9acdfbac70d279023d2c059da13db59594e61ed3354fed5R16) [[2]](diffhunk://#diff-f89763fc11c1bc48ac3c7ce8a148fbbbc5c2062393ee78664a70273d714daf5cR15)

* Added `lodash` version `4.17.21` as a sub-dependency of `express-validator` in `backend/package-lock.json`.

* Added `validator` version `13.12.0` as a sub-dependency of `express-validator` in `backend/package-lock.json`.