### PR TITLE
Swagger UI for API documentation

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,8 +13,8 @@
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "express-validator": "^7.2.1",
-
-        "mariadb": "^3.4.1"
+        "mariadb": "^3.4.1",
+        "swagger-ui-express": "^5.0.1"
       }
     },
     "node_modules/@phc/format": {
@@ -24,6 +24,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
@@ -879,6 +886,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.21.0.tgz",
+      "integrity": "sha512-E0K3AB6HvQd8yQNSMR7eE5bk+323AUxjtCz/4ZNKiahOlPhPJxqn3UPIGs00cyY/dhrTDJ61L7C/a8u6zhGrZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/toidentifier": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "express-validator": "^7.2.1",
-    "mariadb": "^3.4.1"
+    "mariadb": "^3.4.1",
+    "swagger-ui-express": "^5.0.1"
   }
 }

--- a/backend/src/docs/api-spec.json
+++ b/backend/src/docs/api-spec.json
@@ -271,6 +271,84 @@
         ]
       }
     },
+    "/menu/category/{categoryName}": {
+      "get": {
+        "tags": ["Menu"],
+        "summary": "List Menu Items by Category",
+        "description": "Retrieves a list of all available menu items belonging to a specific category.",
+        "parameters": [
+          {
+            "name": "categoryName",
+            "in": "path",
+            "required": true,
+            "description": "The name of the category to retrieve menu items for.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "กาแฟ"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of menu items for the specified category.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Menu"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "message": "Authentication required."
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Category not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "message": "Category 'เครื่องดื่มพิเศษ' not found."
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "message": "An unexpected error occurred while retrieving menus for the category."
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
     "/menu/{menuId}": {
       "get": {
         "tags": ["Menu"],
@@ -2804,8 +2882,7 @@
             "type": "string",
             "description": "Unique 13-digit National ID number. Primary Key for Person.",
             "example": "1266985663999",
-            "pattern": "^\\d{13}$",
-            "readOnly": true
+            "pattern": "^\\d{13}$"
           },
           "firstname": {
             "type": "string",
@@ -2845,7 +2922,12 @@
             "maxLength": 100
           }
         },
-        "required": ["firstname", "lastname", "phoneNum"]
+        "required": [
+          "citizenId",
+          "firstname",
+          "lastname",
+          "phoneNum"
+        ]
       },
       "Employee": {
         "allOf": [
@@ -2875,7 +2957,11 @@
                 "example": 25000
               }
             },
-            "required": ["empId", "empRole", "empSalary"]
+            "required": [
+              "empId",
+              "empRole",
+              "empSalary"
+            ]
           }
         ]
       },
@@ -2924,6 +3010,7 @@
       },
       "EmployeeUpdate": {
         "type": "object",
+        "description": "Fields that can be updated for an employee. citizenId and empId are typically not updatable.",
         "properties": {
           "firstname": {
             "type": "string",
@@ -2975,7 +3062,9 @@
                 "readOnly": true
               }
             },
-            "required": ["point"]
+            "required": [
+              "point"
+            ]
           }
         ]
       },
@@ -2985,10 +3074,13 @@
             "$ref": "#/components/schemas/PersonBase"
           }
         ],
-        "required": ["citizenId"]
+        "required": [
+          "citizenId"
+        ]
       },
       "CustomerUpdate": {
         "type": "object",
+        "description": "Fields that can be updated for a customer. citizenId is typically not updatable.",
         "properties": {
           "firstname": {
             "type": "string",

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,5 +1,7 @@
 const express = require("express");
 const dotenv = require("dotenv");
+const swaggerUi = require('swagger-ui-express');
+const swaggerDocument = require('./docs/api-spec.json');
 
 dotenv.config({path: '.env'});
 
@@ -13,6 +15,8 @@ const customerRouter = require('./routes/customer.route');
 const menuRoutes = require("./routes/menu.route");
 
 app.use(express.json());
+
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 app.use('/order', orderRoutes);
 app.use('/reports', reportsRouter);

--- a/proxy/conf/dafault.conf
+++ b/proxy/conf/dafault.conf
@@ -19,6 +19,10 @@ server {
     proxy_redirect off;
   }
 
+  location /api-docs {
+    proxy_pass http://backend:3000/api-docs;
+  }
+
   location / {
     proxy_pass http://frontend:3000;
 


### PR DESCRIPTION
This pull request introduces Swagger UI to the backend for API documentation and updates the reverse proxy configuration to support it. You can access API docs using [http://localhost/api-docs](http://localhost/api-docs)

### Backend Enhancements

* Added `swagger-ui-express` as a dependency in `backend/package.json` and `backend/package-lock.json` for serving Swagger API documentation.
* Integrated Swagger UI into the backend server by importing `swagger-ui-express` and setting up a new route `/api-docs` to serve the API documentation using the Swagger specification file `api-spec.json`.

### Proxy Configuration

* Updated the reverse proxy configuration in `proxy/conf/dafault.conf` to route requests to `/api-docs` to the backend server, enabling external access to the API documentation.