### PR TITLE
fix(order): correct menu item retrieval in processOrderItem function

### DIFF
--- a/backend/src/controllers/order/createNewOrder.controller.js
+++ b/backend/src/controllers/order/createNewOrder.controller.js
@@ -23,7 +23,7 @@ async function processOrderItem(item, orderId, connection) {
       error: `Menu item with ID ${item.menuId} not found or not available.`,
     };
   }
-  const menuItem = menuItemRows;
+  const menuItem = menuItemRows[0];
   const itemBasePrice = parseFloat(menuItem.MenuPrice);
   let currentItemCustomizeCostPerUnit = 0;
   const customizationsForDb = [];


### PR DESCRIPTION
This pull request includes a small but significant fix in the `processOrderItem` function.

* `backend/src/controllers/order/createNewOrder.controller.js`: Updated the `menuItem` assignment to use the first element of `menuItemRows` (`menuItemRows[0]`) instead of the entire array, ensuring only the intended menu item is processed.